### PR TITLE
make HTML more valid

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,10 +5,10 @@
 
   <ul class="quick-links">
     <li>
-      <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=mdo&repo=wtf-html-css&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112px" height="20px"></iframe>
+      <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=mdo&amp;repo=wtf-html-css&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="112" height="20"></iframe>
     </li>
     <li>
-      <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=mdo&repo=wtf-html-css&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="98px" height="20px"></iframe>
+      <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=mdo&amp;repo=wtf-html-css&amp;type=fork&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="98" height="20"></iframe>
     </li>
   </ul>
   <ul class="quick-links">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
     </title>
 
     <link rel="stylesheet" href="wtf.css">
-    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic|PT+Mono&subset=latin,cyrillic">
+    <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,700,400italic,700italic|PT+Mono&amp;subset=latin,cyrillic">
   </head>
   <body>
 


### PR DESCRIPTION
See http://html5.validator.nu/?doc=http%3A%2F%2Fwtfhtmlcss.com%2F
- Escape unescaped ampersands in GitHub button URLs
- <iframe> width and height attribute values are implicitly in pixels and shouldn't have "px" suffix
