### PR TITLE
Fix emphasis in already emphasized paragraph.

### DIFF
--- a/index.md
+++ b/index.md
@@ -130,7 +130,7 @@ Elements with a `float` will automatically become `display: block;`. Do not set 
 }
 ```
 
-**Fun fact:** *Years ago, we *had* to set `display: inline;` for most floats to work properly in IE6 to avoid the [double margin bug](http://www.positioniseverything.net/explorer/doubled-margin.html). However, those days have long passed.*
+**Fun fact:** *Years ago, we <strong>had</strong> to set `display: inline;` for most floats to work properly in IE6 to avoid the [double margin bug](http://www.positioniseverything.net/explorer/doubled-margin.html). However, those days have long passed.*
 
 
 <a name="vertical-margins-collapse"></a>


### PR DESCRIPTION
Markdown (or at least Github's parser) seems to struggle with nested emphasis markup.
- Both `*[…]*` and `**[…]**` are not parsed correctly.
- `<em>[…]</em>` is visually the same in this context.
- `<em style="font-style: normal;">[…]</em>` is still italic, and ugly.

So I went with `<strong>[…]</strong>`.

reStructuredText's [admonitions](http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions) would nicely avoid this.
