### PR TITLE
Update Carbon Ad Code

### DIFF
--- a/_includes/ads.css
+++ b/_includes/ads.css
@@ -1,7 +1,7 @@
 /* Ads
 -------------------------------------------------- */
 
-#fusionads {
+#carbonads {
   display: block;
   padding: 2rem 0;
   overflow: hidden; /* clearfix */
@@ -10,27 +10,27 @@
   background-color: #fff;
   border-bottom: 1px solid #eee;
 }
-.fusion-text,
-.fusion-poweredby {
+.carbon-text,
+.carbon-poweredby {
   display: block;
   color: #999;
 }
-.fusion-text:hover,
-.fusion-poweredby:hover {
+.carbon-text:hover,
+.carbon-poweredby:hover {
   color: #08c;
   text-decoration: none;
 }
-.fusion-img {
+.carbon-img {
   float: left;
   margin-right: 1rem;
 }
-.fusion-poweredby {
+.carbon-poweredby {
   display: block !important;
   margin-top: .5rem;
 }
 
 @media (min-width: 50rem) {
-  #fusionads {
+  #carbonads {
     position: fixed;
     left: 0;
     bottom: 0;
@@ -40,7 +40,7 @@
     font-size: .6rem;
     border-bottom: 0;
   }
-  .fusion-img {
+  .carbon-img {
     float: none;
     display: block;
     margin-bottom: .5rem;

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,7 +27,7 @@
     {% include header.html %}
 
     <div class="container">
-      <script type="text/javascript" src="//cdn.fusionads.net/fusion.js?zoneid=1332&serve=C6SDP2Y&placement=wtfhtmlcss" id="_fusionads_js"></script>
+      <script async src="//cdn.carbonads.com/carbon.js?serve=CKYI52JY&placement=wtfhtmlcss" id="_carbonads_js"></script>
 
       {{ content }}
     </div>


### PR DESCRIPTION
Replace legacy Fusion ad code with Carbon ad code. We still see some impressions every month, so it's worth replacing the ad code to keep the site error free.