### PR TITLE
Use lowercase doctype

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ layout: default
 Always include a doctype. I recommend the simple HTML5 doctype:
 
 ```html
-<!DOCTYPE html>
+<!doctype html>
 ```
 
 [Skipping the doctype can cause issues](http://quirks.spec.whatwg.org) with malformed tables, inputs, and more as the page will be rendered in quirks mode.


### PR DESCRIPTION
DOCTYPE/doctype is a choice. The two are mostly equal, but everybody should make a strong choice, to avoid needing to think about the choice again.

Here are two arguments for lowercase:

1. Bootstrap recommends lowercase https://getbootstrap.com/docs/5.1/getting-started/introduction/
2. Lowercase letters probably compress better in a HTML transmission stream because there are probably more lowercase letters in the rest of the stream. And because of the Huffman tables.
3. Less finger movement required for typing.